### PR TITLE
Updated pom to include tools.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,4 +44,25 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>default-tools.jar</id>
+            <activation>
+                <property>
+                    <name>java.vendor</name>
+                    <value>Oracle Corporation</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                    <version>${java.version}</version>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Per https://maven.apache.org/general.html#tools-jar-dependency, this should work on all major platforms

**NOTE:** only tested OS X jdk 1.8  and 1.7
