### PR TITLE
Removing unused imports in BaseController

### DIFF
--- a/src/main/java/com/stormpath/examples/idsite_multitenant/controllers/BaseController.java
+++ b/src/main/java/com/stormpath/examples/idsite_multitenant/controllers/BaseController.java
@@ -3,8 +3,6 @@ package com.stormpath.examples.idsite_multitenant.controllers;
 import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.client.Client;
 import com.stormpath.sdk.servlet.http.Resolver;
-import com.stormpath.sdk.servlet.idsite.IdSiteOrganizationContext;
-import com.sun.tools.javac.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 


### PR DESCRIPTION
The reference to com.sun.tools.javac.util.List was pulling in a dependencies on tools.jar, which is not always available
and was causing a compilation error.

Supersedes: #1 
